### PR TITLE
Handling UTF-8 BOM

### DIFF
--- a/position.go
+++ b/position.go
@@ -1,6 +1,7 @@
 package fileset
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"sync"
@@ -141,13 +142,24 @@ func (f *File) SetLinesForContent(content []byte) {
 	f.set.mutex.Unlock()
 }
 
+var utf8bom = []byte{0xef, 0xbb, 0xbf}
+
 func (f *File) SetByteOffsetsForContent(content []byte) {
+
+	offset := 0
+	if len(content) >= 3 {
+		if bytes.HasPrefix(content, utf8bom) {
+			content = content[3:]
+			offset = 3
+		}
+	}
+
 	s := string(content)
 
 	byteOffsetOfRune := make([]int, utf8.RuneCount(content))
 	i := 0
 	for b, _ := range s {
-		byteOffsetOfRune[i] = b
+		byteOffsetOfRune[i] = b + offset
 		i++
 	}
 

--- a/position_test.go
+++ b/position_test.go
@@ -229,3 +229,24 @@ func TestFileByteOffsetOfRune(t *testing.T) {
 		t.Errorf("got `y` byte offset at %d, want %d", yB, want)
 	}
 }
+
+// File set should return offsets starting from 3 for files with UTF-8 BOM
+func TestFileByteOffsetOfRuneWithBOM(t *testing.T) {
+	fset := NewFileSet()
+	b := []byte{0xef, 0xbb, 0xbf, 'x'}
+	f := fset.AddFile("f", fset.Base(), len(b))
+	f.SetByteOffsetsForContent(b)
+
+	xB := f.ByteOffsetOfRune(0)
+	if want := 3; xB != want {
+		t.Errorf("got `x` byte offset at %d, want %d", xB, want)
+	}
+}
+
+// File set should not fail on file that contains only UTF-8 BOM
+func TestFileByteOffsetOfRuneWithBOMEmpty(t *testing.T) {
+	fset := NewFileSet()
+	b := []byte{0xef, 0xbb, 0xbf}
+	f := fset.AddFile("f", fset.Base(), len(b))
+	f.SetByteOffsetsForContent(b)
+}


### PR DESCRIPTION
- when content starts with UTF-8 BOM (0xef, 0xbb, 0xbf), byte offset of first rune is 3; BOM is ignored
